### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/nuxt-emoji-picker/security/code-scanning/3](https://github.com/selemondev/nuxt-emoji-picker/security/code-scanning/3)

To resolve the issue, add a `permissions` block to the workflow to restrict what GITHUB_TOKEN can do. Since no job requires write access (just read access to contents for checking out code), the best fix is to add `permissions: contents: read` at the root level of the workflow (immediately after the `name` and before `on`). This change is minimal, follows the principle of least privilege, and will apply to all jobs in the workflow unless more specific permissions are needed at job level. No additional imports or definitions are necessary; only the YAML needs to be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
