### PR TITLE
chore: workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/nuxt-emoji-picker/security/code-scanning/1](https://github.com/selemondev/nuxt-emoji-picker/security/code-scanning/1)

To fix the problem, you should add a `permissions` key in your workflow YAML. The minimal starting point is `contents: read`, which is commonly enough for many workflows only needing to read code. If any step requires additional privileges (such as creating pull requests or writing releases), specific permissions can be added as needed. For the shown workflow, unless there is a clear need for more, adding `permissions: contents: read` at the root is recommended. This should be placed just after the workflow `name` and before the `on:` key (line 2 or 3).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
